### PR TITLE
fix/pagination(#8): 검색어 입력 API 페이지네이션에서 실제 totalCount 반영하도록 문제 해결

### DIFF
--- a/scripts/fetch.js
+++ b/scripts/fetch.js
@@ -23,6 +23,8 @@ const getData = (start = 1) => {
   )
     .then((response) => response.json())
     .then((data) => {
+      totalCount = data.totalResults;
+      console.log("totalCount update", totalCount, data.totalResults);
       return data.item;
     })
     .catch((error) => {
@@ -49,6 +51,8 @@ const getSearchData = (searchValue, start = 1) => {
   )
     .then((response) => response.json())
     .then((data) => {
+      totalCount = data.totalResults;
+      console.log("totalCount update", totalCount, data.totalResults);
       return data.item;
     })
     .catch((error) => {

--- a/scripts/pagination.js
+++ b/scripts/pagination.js
@@ -9,10 +9,10 @@ const $paginationNumbers = document.querySelector(".paginationNumbers");
  */
 
 let currentPage = 1;
-const totalCount = 200;
+let totalCount = 200;
 const pageCount = 5;
 const limit = 8;
-const totalPage = Math.ceil(totalCount / limit);
+let totalPage = Math.ceil(totalCount / limit);
 
 /**
  * 계산법
@@ -38,7 +38,9 @@ const totalPage = Math.ceil(totalCount / limit);
  * 첫 번쨰 페이지부터 마지막 페이지까지 for문으로 순회하며 버튼 그리기
  */
 
-const calculatePagination = () => {
+const calculatePagination = async () => {
+  await loadBookAPI();
+  totalPage = Math.ceil(totalCount / limit);
   let pageGroup = Math.ceil(currentPage / pageCount);
   let lastNumber = pageGroup * pageCount;
   if (lastNumber > totalPage) {
@@ -50,14 +52,16 @@ const calculatePagination = () => {
   loadPagination(firstNumber, lastNumber);
 };
 
-const loadPagination = (firstNumber, lastNumber) => {
+const loadBookAPI = async () => {
   console.log("load!");
   $books.replaceChildren();
   if ($searchInput.value === "") {
-    loadBooksTemplate(currentPage);
+    await loadBooksTemplate(currentPage);
   } else {
-    loadSearchBooksTemplate($searchInput.value, currentPage);
+    await loadSearchBooksTemplate($searchInput.value, currentPage);
   }
+};
+const loadPagination = (firstNumber, lastNumber) => {
   for (let i = firstNumber; i <= lastNumber; i++) {
     let p = document.createElement("p");
     p.innerHTML = `${i}`;


### PR DESCRIPTION
## 문제
#8 

## 문제 해결
- loadBookAPI를 async, await
- calculatePagination에서 loadBookAPI를 async, await
- 즉, loadBookAPI를 통해 totalCount를 설정한 후, calculatePagination에서 업데이트된 totalCount로 totalPage 업데이트 진행